### PR TITLE
Spectrum Feature: Authentication

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -3,6 +3,8 @@ package spectrum
 type Opts struct {
 	// Addr is the address to listen on.
 	Addr string `yaml:"addr"`
+	// Token is the authentication token Spectrum clients have to use to authenticate with Spectrum.
+	Token string `yaml:"token"`
 	// LatencyInterval is the interval at which the latency of the connection is updated in milliseconds.
 	// The lower the interval, the more accurate the latency will be, but the more bandwidth it will use.
 	LatencyInterval int64 `yaml:"latency_interval"`

--- a/server/conn.go
+++ b/server/conn.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"sync"
+
 	"github.com/cooldogedev/spectrum/internal"
 	proto "github.com/cooldogedev/spectrum/protocol"
 	packet2 "github.com/cooldogedev/spectrum/server/packet"
@@ -12,8 +15,6 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/login"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
-	"net"
-	"sync"
 )
 
 const (
@@ -300,15 +301,17 @@ func (c *Conn) expect(id uint32, deferrable bool) (pk packet.Packet, err error) 
 
 // connect send a connection request to the server with the address, clientData and identityData passed. It returns
 // an error if the server doesn't respond.
-func (c *Conn) connect(addr string, clientData login.ClientData, identityData login.IdentityData) (err error) {
+func (c *Conn) connect(addr string, token string, clientData login.ClientData, identityData login.IdentityData) (err error) {
 	clientDataBytes, _ := json.Marshal(clientData)
 	identityDataBytes, _ := json.Marshal(identityData)
 
 	err = c.WritePacket(&packet2.ConnectionRequest{
 		Addr:         addr,
+		Token:        token,
 		ClientData:   clientDataBytes,
 		IdentityData: identityDataBytes,
 	})
+
 	if err != nil {
 		return fmt.Errorf("failed to write connect packet: %v", err)
 	}

--- a/server/dialer.go
+++ b/server/dialer.go
@@ -1,13 +1,15 @@
 package server
 
 import (
+	"net"
+
 	"github.com/sandertv/gophertunnel/minecraft/protocol/login"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
-	"net"
 )
 
 type Dialer struct {
 	Origin       string
+	Token 		 string
 	ClientData   login.ClientData
 	IdentityData login.IdentityData
 }
@@ -25,5 +27,5 @@ func (d Dialer) Dial(addr string) (*Conn, error) {
 		_ = tcpConn.SetWriteBuffer(1024 * 1024 * 8)
 	}
 	c := NewConn(conn, packet.NewServerPool())
-	return c, c.connect(d.Origin, d.ClientData, d.IdentityData)
+	return c, c.connect(d.Origin, d.Token, d.ClientData, d.IdentityData)
 }

--- a/server/packet/connection_request.go
+++ b/server/packet/connection_request.go
@@ -6,6 +6,7 @@ import (
 
 type ConnectionRequest struct {
 	Addr         string
+	Token 		 string
 	ClientData   []byte
 	IdentityData []byte
 }
@@ -16,6 +17,7 @@ func (pk *ConnectionRequest) ID() uint32 {
 
 func (pk *ConnectionRequest) Marshal(io protocol.IO) {
 	io.String(&pk.Addr)
+	io.String(&pk.Token)
 	io.ByteSlice(&pk.ClientData)
 	io.ByteSlice(&pk.IdentityData)
 }

--- a/spectrum.go
+++ b/spectrum.go
@@ -49,7 +49,7 @@ func (s *Spectrum) Accept() (*session.Session, error) {
 		return nil, err
 	}
 
-	newSession, err := session.NewSession(conn.(*minecraft.Conn), s.logger, s.registry, s.discovery, s.opts.LatencyInterval)
+	newSession, err := session.NewSession(conn.(*minecraft.Conn), s.opts.Token, s.logger, s.registry, s.discovery, s.opts.LatencyInterval)
 	if err != nil {
 		s.logger.Errorf("Failed to create session: %v", err)
 		return nil, err


### PR DESCRIPTION
This PR implements authentication and resolves https://github.com/cooldogedev/spectrum/issues/4.

All clients now have to pass in a token that matches with the proxy's token in order to authenticate and join.