### PR TITLE
feat: Option for full graceful shutdown

### DIFF
--- a/spectrum.go
+++ b/spectrum.go
@@ -108,7 +108,7 @@ func (s *Spectrum) Transport() tr.Transport {
 // Close closes the listener and stops listening for incoming connections.
 func (s *Spectrum) Close() error {
 	for _, activeSession := range s.registry.GetSessions() {
-		_ = activeSession.Close()
+		activeSession.Disconnect(s.opts.ShutdownMessage)
 	}
 	return s.listener.Close()
 }

--- a/util/opts.go
+++ b/util/opts.go
@@ -9,7 +9,7 @@ type Opts struct {
 	// LatencyInterval is the interval at which the latency of the connection is updated in milliseconds.
 	// Lower intervals provide more accurate latency but use more bandwidth.
 	LatencyInterval int64 `yaml:"latency_interval"`
-	// ShutdownMessage is the message that will be displayed to clients when proxy closes.
+	// ShutdownMessage is the message displayed to clients when Spectrum shuts down.
 	ShutdownMessage string `yaml:"shutdown_message"`
 	// Token is the authentication token that Spectrum uses to authenticate with servers.
 	Token string `yaml:"token"`
@@ -21,6 +21,6 @@ func DefaultOpts() *Opts {
 		Addr:            ":19132",
 		AutoLogin:       true,
 		LatencyInterval: 3000,
-		ShutdownMessage: "Proxy closed",
+		ShutdownMessage: "Spectrum closed.",
 	}
 }

--- a/util/opts.go
+++ b/util/opts.go
@@ -9,6 +9,8 @@ type Opts struct {
 	// LatencyInterval is the interval at which the latency of the connection is updated in milliseconds.
 	// Lower intervals provide more accurate latency but use more bandwidth.
 	LatencyInterval int64 `yaml:"latency_interval"`
+	// ShutdownMessage is the message that will be displayed to clients when proxy closes.
+	ShutdownMessage string `yaml:"shutdown_message"`
 	// Token is the authentication token that Spectrum uses to authenticate with servers.
 	Token string `yaml:"token"`
 }
@@ -19,5 +21,6 @@ func DefaultOpts() *Opts {
 		Addr:            ":19132",
 		AutoLogin:       true,
 		LatencyInterval: 3000,
+		ShutdownMessage: "Proxy closed",
 	}
 }


### PR DESCRIPTION
Without DisconnectPacket clients will stay on unexisting server questioning their existence in this big dark cold world. This method makes sure to inform clients about disconnection before closing the listener.