### PR TITLE
Small issue with kick packets using the build in API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -45,7 +45,7 @@ func NewAPI(registry *session.Registry, logger *slog.Logger, authentication Auth
 	}
 	a.RegisterHandler(packet.IDKick, func(_ *Client, pk packet.Packet) {
 		username := pk.(*packet.Kick).Username
-		reason := pk.(*packet.Kick).Username
+		reason := pk.(*packet.Kick).Reason
 		if s := a.registry.GetSessionByUsername(username); s != nil {
 			s.Disconnect(reason)
 		} else {


### PR DESCRIPTION
This pull request addresses a critical correction in the handling of the Kick packet by properly assigning the reason variable to the actual Reason field provided in the packet, rather than mistakenly assigning it to the Username field as was previously implemented. The original code incorrectly used pk.(*packet.Kick).Username for both the username and reason variables. This oversight led to the username being displayed or logged as the reason a player was kicked, which not only fails to convey the actual reason for disconnection but also introduces unnecessary confusion for both users and server administrators. When a player is forcibly disconnected from the server, especially in automated or administrative scenarios, it is essential that the reason string accurately reflects the cause—whether it be due to rule violations, server-side checks, connection issues, or other administrative actions. Logging the username as the reason undermines the usefulness of server logs, hinders debugging, and makes it difficult for support teams to provide accurate assistance when reviewing player disconnections.

Moreover, this change enhances the transparency of server-client interactions by ensuring that users receive meaningful feedback when they are kicked. Instead of seeing an unexplained or confusing message (such as their own username), they will now be shown the intended reason, which can help them understand what went wrong and what they might need to do to resolve the issue or avoid it in the future. For developers, this fix significantly improves traceability in logs by accurately correlating usernames with their corresponding kick reasons, allowing for better audit trails and analytics in systems that track player behavior or connection quality. It also supports clearer diagnostics when investigating unusual patterns of disconnections or potential misuse of the kick feature.

From a maintenance and scalability perspective, this fix reduces technical debt by eliminating a silent logic bug that could propagate further confusion across features that depend on accurate kick reasons, such as moderation dashboards, player analytics, or automatic ban enforcement systems. By aligning the code with its intended purpose—retrieving and using the actual Reason field from the Kick packet—this change restores semantic clarity, preserves data integrity, and helps enforce a more robust and predictable network protocol implementation. This improvement, although small in code, has a large impact on usability, reliability, and the overall professionalism of the system.