### PR TITLE
Add ability to change Discovery by Processor

### DIFF
--- a/session/processor.go
+++ b/session/processor.go
@@ -39,6 +39,10 @@ type Processor interface {
 	ProcessClientEncoded(ctx *Context, pk *[]byte)
 	// ProcessFlush is called before flushing the player's minecraft.Conn buffer in response to a downstream server request.
 	ProcessFlush(ctx *Context)
+	// ProcessDiscover is called to determine the primary server to send the player to.
+	ProcessDiscover(ctx *Context, target *string)
+	// ProcessDiscoverFallback is called to determine the fallback server to send the player to.
+	ProcessDiscoverFallback(ctx *Context, target *string)
 	// ProcessPreTransfer is called before transferring the player to a different server.
 	ProcessPreTransfer(ctx *Context, origin *string, target *string)
 	// ProcessTransferFailure is called when the player transfer to a different server fails.
@@ -63,6 +67,8 @@ func (NopProcessor) ProcessServerEncoded(_ *Context, _ *[]byte)              {}
 func (NopProcessor) ProcessClient(_ *Context, _ *packet.Packet)              {}
 func (NopProcessor) ProcessClientEncoded(_ *Context, _ *[]byte)              {}
 func (NopProcessor) ProcessFlush(_ *Context)                                 {}
+func (NopProcessor) ProcessDiscover(_ *Context)                              {}
+func (NopProcessor) ProcessDiscoverFallback(_ *Context)                      {}
 func (NopProcessor) ProcessPreTransfer(_ *Context, _ *string, _ *string)     {}
 func (NopProcessor) ProcessTransferFailure(_ *Context, _ *string, _ *string) {}
 func (NopProcessor) ProcessPostTransfer(_ *Context, _ *string, _ *string)    {}

--- a/session/processor.go
+++ b/session/processor.go
@@ -67,8 +67,8 @@ func (NopProcessor) ProcessServerEncoded(_ *Context, _ *[]byte)              {}
 func (NopProcessor) ProcessClient(_ *Context, _ *packet.Packet)              {}
 func (NopProcessor) ProcessClientEncoded(_ *Context, _ *[]byte)              {}
 func (NopProcessor) ProcessFlush(_ *Context)                                 {}
-func (NopProcessor) ProcessDiscover(_ *Context)                              {}
-func (NopProcessor) ProcessDiscoverFallback(_ *Context)                      {}
+func (NopProcessor) ProcessDiscover(_ *Context, target *string)              {}
+func (NopProcessor) ProcessDiscoverFallback(_ *Context, target *string)      {}
 func (NopProcessor) ProcessPreTransfer(_ *Context, _ *string, _ *string)     {}
 func (NopProcessor) ProcessTransferFailure(_ *Context, _ *string, _ *string) {}
 func (NopProcessor) ProcessPostTransfer(_ *Context, _ *string, _ *string)    {}

--- a/session/session.go
+++ b/session/session.go
@@ -96,6 +96,8 @@ func (s *Session) LoginContext(ctx context.Context) (err error) {
 		return err
 	}
 
+	s.Processor().ProcessDiscover(NewContext(), &serverAddr)
+
 	conn, err := s.dial(ctx, serverAddr)
 	if err != nil {
 		s.logger.Debug("dialer failed", "err", err)
@@ -324,6 +326,8 @@ func (s *Session) fallback() error {
 	if err != nil {
 		return fmt.Errorf("discovery failed: %w", err)
 	}
+
+	s.Processor().ProcessDiscoverFallback(NewContext(), &addr)
 
 	s.logger.Debug("transferring session to a fallback server", "addr", addr)
 	if err := s.Transfer(addr); err != nil {


### PR DESCRIPTION
Adding this follows the rest of the code in the processor allowing proxy actions to be changed on a per player basis. This can be useful for when you load information into the processor (ex permissions from a database) to determine if the player can continue to the server the Discovery selected.