### PR TITLE
Harden transport dial paths and API/session validation

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -160,7 +160,7 @@ func (a *API) handle(c *Client, id int64) {
 
 	if a.authentication != nil && !a.authentication.Authenticate(connectionRequest.Token) {
 		_ = c.WritePacket(&packet.ConnectionResponse{Response: packet.ResponseUnauthorized})
-		a.logger.Error("unauthorized connection", "addr", addr, "token", connectionRequest.Token)
+		a.logger.Error("unauthorized connection", "addr", addr)
 		return
 	}
 

--- a/api/authentication.go
+++ b/api/authentication.go
@@ -1,6 +1,6 @@
 package api
 
-import "strings"
+import "crypto/subtle"
 
 // Authentication defines an interface for authentication methods.
 type Authentication interface {
@@ -22,5 +22,5 @@ func NewSecretBasedAuthentication(secret string) *SecretBasedAuthentication {
 
 // Authenticate ...
 func (authentication *SecretBasedAuthentication) Authenticate(token string) bool {
-	return strings.EqualFold(authentication.secret, token)
+	return subtle.ConstantTimeCompare([]byte(authentication.secret), []byte(token)) == 1
 }

--- a/api/dial.go
+++ b/api/dial.go
@@ -35,7 +35,7 @@ func Dial(addr, token string) (c *Client, err error) {
 
 	connectionResponse, ok := connectionResponsePacket.(*packet.ConnectionResponse)
 	if !ok {
-		return nil, fmt.Errorf("expected connection response, got %d", connectionResponse.ID())
+		return nil, fmt.Errorf("expected connection response, got %d", connectionResponsePacket.ID())
 	}
 
 	if connectionResponse.Response == packet.ResponseFail {
@@ -47,7 +47,7 @@ func Dial(addr, token string) (c *Client, err error) {
 	}
 
 	if connectionResponse.Response != packet.ResponseSuccess {
-		return nil, fmt.Errorf("received an unknown response code %d", connectionResponse.ID())
+		return nil, fmt.Errorf("received an unknown response code %d", connectionResponse.Response)
 	}
 	return c, nil
 }

--- a/api/packet/connection_response.go
+++ b/api/packet/connection_response.go
@@ -30,5 +30,7 @@ func (pk *ConnectionResponse) Encode(buf *bytes.Buffer) {
 
 // Decode ...
 func (pk *ConnectionResponse) Decode(buf *bytes.Buffer) {
-	_ = binary.Read(buf, binary.LittleEndian, pk.Response)
+	if err := binary.Read(buf, binary.LittleEndian, &pk.Response); err != nil {
+		pk.Response = ResponseFail
+	}
 }

--- a/api/packet/encoding.go
+++ b/api/packet/encoding.go
@@ -5,11 +5,18 @@ import (
 	"encoding/binary"
 )
 
+const maxAPIStringLength = 1024 * 1024
+
 // ReadString reads a string from buf, where the string is prefixed with its length
 // encoded as an uint32 in little-endian order.
 func ReadString(buf *bytes.Buffer) string {
 	var length uint32
-	_ = binary.Read(buf, binary.LittleEndian, &length)
+	if err := binary.Read(buf, binary.LittleEndian, &length); err != nil {
+		return ""
+	}
+	if length > maxAPIStringLength || int(length) > buf.Len() {
+		return ""
+	}
 	data := make([]byte, length)
 	_, _ = buf.Read(data)
 	return string(data)
@@ -18,6 +25,9 @@ func ReadString(buf *bytes.Buffer) string {
 // WriteString writes the string s to buf, prefixing it with its length encoded
 // as an uint32 in little-endian order.
 func WriteString(buf *bytes.Buffer, s string) {
+	if len(s) > maxAPIStringLength {
+		s = s[:maxAPIStringLength]
+	}
 	_ = binary.Write(buf, binary.LittleEndian, uint32(len(s)))
 	buf.Write([]byte(s))
 }

--- a/protocol/reader.go
+++ b/protocol/reader.go
@@ -6,6 +6,8 @@ import (
 	"io"
 )
 
+const maxPacketLength = 16 * 1024 * 1024
+
 // Reader is used for reading packets from an io.Reader.
 type Reader struct {
 	// r is the underlying io.Reader used for reading data.
@@ -24,6 +26,12 @@ func (r *Reader) ReadPacket() ([]byte, error) {
 	var length uint32
 	if err := binary.Read(r.r, binary.BigEndian, &length); err != nil {
 		return nil, fmt.Errorf("failed to read packet length: %w", err)
+	}
+	if length == 0 {
+		return nil, fmt.Errorf("invalid packet length: %d", length)
+	}
+	if length > maxPacketLength {
+		return nil, fmt.Errorf("packet length %d exceeds maximum %d", length, maxPacketLength)
 	}
 
 	pk := make([]byte, length)

--- a/server/conn.go
+++ b/server/conn.go
@@ -273,6 +273,9 @@ func (c *Conn) read() (pk any, err error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(payload) == 0 {
+		return nil, errors.New("empty packet payload")
+	}
 
 	if payload[0] != packetDecodeNeeded && payload[0] != packetDecodeNotNeeded {
 		return nil, fmt.Errorf("unknown decode byte marker %v", payload[0])

--- a/session/handler.go
+++ b/session/handler.go
@@ -110,7 +110,9 @@ loop:
 		}
 
 		if err := handleClientPacket(s, header, pool, shieldID, payload); err != nil {
-			s.Server().CloseWithError(fmt.Errorf("failed to write packet to server: %w", err))
+			if server := s.Server(); server != nil {
+				server.CloseWithError(fmt.Errorf("failed to write packet to server: %w", err))
+			}
 		}
 	}
 }
@@ -119,6 +121,10 @@ loop:
 // The client's latency is derived from half of RakNet's round-trip time (RTT).
 // To calculate the total latency, we multiply this value by 2.
 func handleLatency(s *Session, interval int64) {
+	if interval <= 0 {
+		s.logger.Warn("invalid latency interval, using default", "interval", interval, "default", int64(3000))
+		interval = 3000
+	}
 	ticker := time.NewTicker(time.Millisecond * time.Duration(interval))
 	defer ticker.Stop()
 loop:

--- a/session/session.go
+++ b/session/session.go
@@ -43,10 +43,11 @@ type Session struct {
 	processor   Processor
 	processorMu sync.RWMutex
 
-	cache      atomic.Value
-	latency    atomic.Int64
-	inFallback atomic.Bool
-	once       sync.Once
+	cache        atomic.Value
+	latency      atomic.Int64
+	inFallback   atomic.Bool
+	transferring atomic.Bool
+	once         sync.Once
 }
 
 // NewSession creates a new Session instance using the provided minecraft.Conn.
@@ -160,20 +161,23 @@ func (s *Session) TransferContext(ctx context.Context, addr string) (err error) 
 	if processorCtx.Cancelled() {
 		return errors.New("processor failed")
 	}
+	if !s.transferring.CompareAndSwap(false, true) {
+		return errors.New("transfer already in progress")
+	}
+	releaseTransfer := func() {
+		s.transferring.Store(false)
+	}
 
 	s.sendMetadata(true)
 	conn, err := s.dial(ctx, addr)
 	if err != nil {
+		releaseTransfer()
 		s.Processor().ProcessTransferFailure(NewContext(), &origin, &addr)
 		return fmt.Errorf("dialer failed: %w", err)
 	}
 
-	if err := conn.DoConnect(); err != nil {
-		s.Processor().ProcessTransferFailure(NewContext(), &origin, &addr)
-		return fmt.Errorf("connection sequence failed failed: %w", err)
-	}
-
 	conn.OnConnect(func(err error) {
+		defer releaseTransfer()
 		if err != nil {
 			s.Processor().ProcessTransferFailure(NewContext(), &origin, &addr)
 			return
@@ -191,6 +195,12 @@ func (s *Session) TransferContext(ctx context.Context, addr string) (err error) 
 		s.Processor().ProcessPostTransfer(NewContext(), &origin, &addr)
 		s.logger.Debug("transferred session", "origin", origin, "target", addr)
 	})
+
+	if err := conn.DoConnect(); err != nil {
+		releaseTransfer()
+		s.Processor().ProcessTransferFailure(NewContext(), &origin, &addr)
+		return fmt.Errorf("connection sequence failed: %w", err)
+	}
 	return nil
 }
 

--- a/spectrum.go
+++ b/spectrum.go
@@ -29,8 +29,19 @@ type Spectrum struct {
 // It initializes opts with default options from util.DefaultOpts() if opts is nil,
 // and defaults to TCP transport if transport is nil transport.TCP.
 func NewSpectrum(discovery server.Discovery, logger *slog.Logger, opts *util.Opts, transport tr.Transport) *Spectrum {
+	defaults := util.DefaultOpts()
 	if opts == nil {
-		opts = util.DefaultOpts()
+		opts = defaults
+	} else {
+		if opts.Addr == "" {
+			opts.Addr = defaults.Addr
+		}
+		if opts.LatencyInterval <= 0 {
+			opts.LatencyInterval = defaults.LatencyInterval
+		}
+		if opts.ShutdownMessage == "" {
+			opts.ShutdownMessage = defaults.ShutdownMessage
+		}
 	}
 
 	if transport == nil {

--- a/transport/quic.go
+++ b/transport/quic.go
@@ -18,6 +18,7 @@ import (
 // resource utilization.
 type QUIC struct {
 	connections map[string]*quic.Conn
+	tlsConfig   *tls.Config
 	logger      *slog.Logger
 	mu          sync.Mutex
 }
@@ -26,24 +27,63 @@ type QUIC struct {
 func NewQUIC(logger *slog.Logger) *QUIC {
 	return &QUIC{
 		connections: make(map[string]*quic.Conn),
-		logger:      logger,
+		tlsConfig: &tls.Config{
+			MinVersion: tls.VersionTLS13,
+			NextProtos: []string{"spectrum"},
+		},
+		logger: logger,
+	}
+}
+
+// NewQUICInsecure creates a QUIC transport that skips certificate verification.
+// It is intended for development and testing only.
+func NewQUICInsecure(logger *slog.Logger) *QUIC {
+	return &QUIC{
+		connections: make(map[string]*quic.Conn),
+		tlsConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS13,
+			NextProtos:         []string{"spectrum"},
+		},
+		logger: logger,
 	}
 }
 
 // Dial ...
 func (q *QUIC) Dial(ctx context.Context, addr string) (io.ReadWriteCloser, error) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
+	conn, err := q.getOrDial(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
 
+	stream, err := conn.OpenStreamSync(ctx)
+	if err != nil {
+		if conn.Context().Err() != nil {
+			q.mu.Lock()
+			if found, ok := q.connections[addr]; ok && found == conn {
+				delete(q.connections, addr)
+			}
+			q.mu.Unlock()
+		}
+		return nil, err
+	}
+	return stream, nil
+}
+
+func (q *QUIC) getOrDial(ctx context.Context, addr string) (*quic.Conn, error) {
+	q.mu.Lock()
 	conn, ok := q.connections[addr]
+	q.mu.Unlock()
 	if !ok {
+		tlsConfig := q.tlsConfig
+		if tlsConfig == nil {
+			tlsConfig = &tls.Config{MinVersion: tls.VersionTLS13, NextProtos: []string{"spectrum"}}
+		}
+
 		c, err := quic.DialAddr(
 			ctx,
 			addr,
-			&tls.Config{
-				InsecureSkipVerify: true,
-				NextProtos:         []string{"spectrum"},
-			},
+			tlsConfig.Clone(),
 			&quic.Config{
 				MaxIdleTimeout:                 time.Second * 10,
 				InitialStreamReceiveWindow:     1024 * 1024 * 10,
@@ -57,8 +97,16 @@ func (q *QUIC) Dial(ctx context.Context, addr string) (io.ReadWriteCloser, error
 			return nil, err
 		}
 
+		q.mu.Lock()
+		if existing, exists := q.connections[addr]; exists {
+			q.mu.Unlock()
+			_ = c.CloseWithError(0, "duplicate connection")
+			return existing, nil
+		}
+
 		conn = c
 		q.connections[addr] = conn
+		q.mu.Unlock()
 		q.logger.Debug("established connection", "addr", addr)
 		go func(conn *quic.Conn, addr string) {
 			<-conn.Context().Done()
@@ -70,10 +118,5 @@ func (q *QUIC) Dial(ctx context.Context, addr string) (io.ReadWriteCloser, error
 			q.logger.Debug("closed connection", "addr", addr, "cause", context.Cause(conn.Context()))
 		}(conn, addr)
 	}
-	stream, err := conn.OpenStreamSync(ctx)
-	if err != nil {
-		delete(q.connections, addr)
-		return nil, err
-	}
-	return stream, nil
+	return conn, nil
 }

--- a/transport/spectral.go
+++ b/transport/spectral.go
@@ -29,18 +29,45 @@ func NewSpectral(logger *slog.Logger) *Spectral {
 
 // Dial ...
 func (s *Spectral) Dial(ctx context.Context, addr string) (io.ReadWriteCloser, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	conn, err := s.getOrDial(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
 
+	stream, err := conn.OpenStream(ctx)
+	if err != nil {
+		if conn.Context().Err() != nil {
+			s.mu.Lock()
+			if found, ok := s.connections[addr]; ok && found == conn {
+				delete(s.connections, addr)
+			}
+			s.mu.Unlock()
+		}
+		return nil, err
+	}
+	return stream, nil
+}
+
+func (s *Spectral) getOrDial(ctx context.Context, addr string) (spectral.Connection, error) {
+	s.mu.Lock()
 	conn, ok := s.connections[addr]
+	s.mu.Unlock()
 	if !ok {
 		c, err := spectral.Dial(ctx, addr)
 		if err != nil {
 			return nil, err
 		}
 
+		s.mu.Lock()
+		if existing, exists := s.connections[addr]; exists {
+			s.mu.Unlock()
+			_ = c.CloseWithError(0, "duplicate connection")
+			return existing, nil
+		}
+
 		conn = c
 		s.connections[addr] = conn
+		s.mu.Unlock()
 		s.logger.Debug("established connection", "addr", addr)
 		go func(conn spectral.Connection, addr string) {
 			<-conn.Context().Done()
@@ -52,10 +79,5 @@ func (s *Spectral) Dial(ctx context.Context, addr string) (io.ReadWriteCloser, e
 			s.logger.Debug("closed connection", "addr", addr, "cause", context.Cause(conn.Context()))
 		}(conn, addr)
 	}
-	stream, err := conn.OpenStream(ctx)
-	if err != nil {
-		delete(s.connections, addr)
-		return nil, err
-	}
-	return stream, nil
+	return conn, nil
 }


### PR DESCRIPTION
## Summary
- Fix API authentication response decoding and dial error reporting so auth failures cannot be misinterpreted as success.
- Strengthen API auth handling by switching to constant-time token comparison and removing raw token values from logs.
- Add packet/string length validation and empty-payload guards to reduce malformed-input crash and memory DoS risk.
- Prevent transfer lockups by guarding concurrent transfers and registering `OnConnect` before connect starts.
- Add latency-loop safety guards: clamp invalid latency intervals to defaults with warning logs and avoid nil-server close panics on client packet errors.
- Apply option sanitization even when `opts` is provided (fill empty/zero fields from defaults) to avoid misconfiguration panics.
- Refactor Spectral/QUIC dial paths to avoid lock-held network I/O and stale connection-map leaks under load.
- Make QUIC secure by default and add explicit `NewQUICInsecure` opt-in for development/testing.

## Validation
- `go test github.com/cooldogedev/spectrum github.com/cooldogedev/spectrum/api github.com/cooldogedev/spectrum/api/packet github.com/cooldogedev/spectrum/protocol github.com/cooldogedev/spectrum/server github.com/cooldogedev/spectrum/server/packet github.com/cooldogedev/spectrum/session github.com/cooldogedev/spectrum/session/animation github.com/cooldogedev/spectrum/transport github.com/cooldogedev/spectrum/util`
- `go vet github.com/cooldogedev/spectrum github.com/cooldogedev/spectrum/api github.com/cooldogedev/spectrum/api/packet github.com/cooldogedev/spectrum/protocol github.com/cooldogedev/spectrum/server github.com/cooldogedev/spectrum/server/packet github.com/cooldogedev/spectrum/session github.com/cooldogedev/spectrum/session/animation github.com/cooldogedev/spectrum/transport github.com/cooldogedev/spectrum/util`